### PR TITLE
fix_migration

### DIFF
--- a/database/migrations/audits_extra.stub
+++ b/database/migrations/audits_extra.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddAuditsTableExtra extends Migration
+class PushAuditsExtra extends Migration
 {
     /**
      * Run the migrations.

--- a/src/LaravelAuditingServiceProvider.php
+++ b/src/LaravelAuditingServiceProvider.php
@@ -82,7 +82,7 @@ class LaravelAuditingServiceProvider extends ServiceProvider
 
             $this->publishes([
                 __DIR__.'/../database/migrations/audits_extra.stub' => database_path(
-                    sprintf('migrations/%s_add_audits_extra.php', date('Y_m_d_His'))
+                    sprintf('migrations/%s_push_audits_extra.php', date('Y_m_d_His'))
                 ),
             ], 'migrations-0.3');
         }


### PR DESCRIPTION
после выполнения `php artisan vendor:publish --provider="Ensi\LaravelAuditing\LaravelAuditingServiceProvider"` создаются две миграции:

```
2022_11_15_073515_add_audits_extra.php
2022_11_15_073515_create_audits_table.php
```

интересует миграция `2022_11_15_073515_add_audits_extra.php`

выполняю `php artisan migrate` и получаю `Cannot declare class AddAuditsTableExtra, because the name is already in use`

по правилам именования `add_audits_extra` не соответствует названию класса миграции `AddAuditsTableExtra`

если убрать `Table` из `AddAuditsTableExtra` все должно работать, но при выполнении `php artisan migrate` ошибка `Undefined table` тк первой выполняется миграция `2022_11_15_073515_add_audits_extra.php`

причина в том что после метки времени миграции сортируются по алфавиту и получается такой порядок

```
2022_11_15_073515_add_audits_extra.php
2022_11_15_073515_create_audits_table.php
```

чтобы не мучиться с временной меткой изменил название `add_audits_extra` на `push_audits_extra` и тогда они выполняются по порядку